### PR TITLE
chore: upgrade Java from 21 to 25

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "21"
+          java-version: "25"
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,11 +11,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "21"
+          java-version: "25"
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 This is a **production-grade Spring Boot backend** project that demonstrates best practices for building secure, OpenAPI-driven REST APIs with robust local development and testing environments.
 
 ### Key Characteristics
-- **Primary Language**: Java 21
+- **Primary Language**: Java 25
 - **Framework**: Spring Boot 3.5.6
 - **Build Tool**: Gradle 
 - **Database**: PostgreSQL with Flyway migrations
@@ -74,7 +74,7 @@ This is a **production-grade Spring Boot backend** project that demonstrates bes
 ## Working with This Repository
 
 ### Prerequisites for Development
-1. **Java 21** (required)
+1. **Java 25** (required)
 2. **Docker & Docker Compose** (for local services)
 3. **Gradle** (wrapper included)
 
@@ -253,7 +253,7 @@ Create `.vscode/launch.json`:
 ### Common Issues
 
 #### Build Failures
-- Ensure Java 21 is installed and active
+- Ensure Java 25 is installed and active
 - Run `./gradlew clean build` for clean rebuild
 - Check OpenAPI spec syntax if generation fails
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Update `build.gradle` toolchain to `JavaLanguageVersion.of(25)`
- Update CI workflows (`pull-request.yml`, `ci-cd.yml`) to use JDK 25 via `actions/setup-java`
- Update `AGENTS.md` to reflect Java 25 as the required version

## Test plan

- [ ] Ensure Java 25 is installed locally (`sdk install java 25-tem` or equivalent)
- [ ] Run `./gradlew build` and confirm it compiles against Java 25 toolchain
- [ ] Run `./gradlew test` and confirm all tests pass
- [ ] Verify CI pipeline picks up JDK 25 in both PR and main workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)